### PR TITLE
Add Gun component rotation

### DIFF
--- a/project/src/PlayerController.gd
+++ b/project/src/PlayerController.gd
@@ -12,6 +12,11 @@ extends CharacterBody2D
 
 func _physics_process(_delta):
 	
+	if is_facing_left():
+		gun_component.rotate_gun_left()
+	else:
+		gun_component.rotate_gun_right()
+
 	if is_attack_frame():
 		gun_component.attack()
 	

--- a/project/src/PlayerController.gd
+++ b/project/src/PlayerController.gd
@@ -12,10 +12,7 @@ extends CharacterBody2D
 
 func _physics_process(_delta):
 	
-	if is_facing_left():
-		gun_component.rotate_gun_left()
-	else:
-		gun_component.rotate_gun_right()
+	gun_component.rotate_gun(is_facing_left())
 
 	if is_attack_frame():
 		gun_component.attack()

--- a/project/src/PlayerController.tscn
+++ b/project/src/PlayerController.tscn
@@ -7,10 +7,11 @@
 [ext_resource type="PackedScene" uid="uid://bs6jn61nhxn4t" path="res://src/components/HealthComponent.tscn" id="8_5vbbj"]
 [ext_resource type="Script" path="res://src/XpTracker.gd" id="9_arjqf"]
 [ext_resource type="PackedScene" uid="uid://bfijyvtr0ia6e" path="res://src/guns/PipePistol.tscn" id="9_kj7hj"]
+[ext_resource type="PackedScene" uid="uid://bfijyvtr0ia6e" path="res://src/guns/PipePistol.tscn" id="9_kj7hj"]
 [ext_resource type="PackedScene" uid="uid://b4xp22aygegm6" path="res://src/components/CharSoundComponent.tscn" id="9_p65x4"]
 [ext_resource type="PackedScene" uid="uid://bwv73goppw5ma" path="res://src/components/InvulnerabilityComponent.tscn" id="10_x4bqf"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_l1y0s"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_i80tj"]
 resource_local_to_scene = true
 shader = ExtResource("6")
 shader_parameter/active = false
@@ -33,9 +34,10 @@ gun_component = NodePath("PipePistol")
 xp_tracker = NodePath("XpTracker")
 
 [node name="CharSpriteComponent" parent="." instance=ExtResource("2_q0te6")]
-material = SubResource("ShaderMaterial_l1y0s")
+material = SubResource("ShaderMaterial_i80tj")
 
 [node name="PipePistol" parent="." instance=ExtResource("9_kj7hj")]
+position = Vector2(-6, 1)
 position = Vector2(-6, 1)
 
 [node name="PlayerColisionShape2D" type="CollisionShape2D" parent="."]

--- a/project/src/PlayerController.tscn
+++ b/project/src/PlayerController.tscn
@@ -7,11 +7,10 @@
 [ext_resource type="PackedScene" uid="uid://bs6jn61nhxn4t" path="res://src/components/HealthComponent.tscn" id="8_5vbbj"]
 [ext_resource type="Script" path="res://src/XpTracker.gd" id="9_arjqf"]
 [ext_resource type="PackedScene" uid="uid://bfijyvtr0ia6e" path="res://src/guns/PipePistol.tscn" id="9_kj7hj"]
-[ext_resource type="PackedScene" uid="uid://bfijyvtr0ia6e" path="res://src/guns/PipePistol.tscn" id="9_kj7hj"]
 [ext_resource type="PackedScene" uid="uid://b4xp22aygegm6" path="res://src/components/CharSoundComponent.tscn" id="9_p65x4"]
 [ext_resource type="PackedScene" uid="uid://bwv73goppw5ma" path="res://src/components/InvulnerabilityComponent.tscn" id="10_x4bqf"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_un07t"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_t8amc"]
 resource_local_to_scene = true
 shader = ExtResource("6")
 shader_parameter/active = false
@@ -34,10 +33,9 @@ gun_component = NodePath("PipePistol")
 xp_tracker = NodePath("XpTracker")
 
 [node name="CharSpriteComponent" parent="." instance=ExtResource("2_q0te6")]
-material = SubResource("ShaderMaterial_un07t")
+material = SubResource("ShaderMaterial_t8amc")
 
 [node name="PipePistol" parent="." instance=ExtResource("9_kj7hj")]
-position = Vector2(-6, 1)
 position = Vector2(-6, 1)
 
 [node name="PlayerColisionShape2D" type="CollisionShape2D" parent="."]

--- a/project/src/PlayerController.tscn
+++ b/project/src/PlayerController.tscn
@@ -11,7 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://b4xp22aygegm6" path="res://src/components/CharSoundComponent.tscn" id="9_p65x4"]
 [ext_resource type="PackedScene" uid="uid://bwv73goppw5ma" path="res://src/components/InvulnerabilityComponent.tscn" id="10_x4bqf"]
 
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_i80tj"]
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_un07t"]
 resource_local_to_scene = true
 shader = ExtResource("6")
 shader_parameter/active = false
@@ -34,7 +34,7 @@ gun_component = NodePath("PipePistol")
 xp_tracker = NodePath("XpTracker")
 
 [node name="CharSpriteComponent" parent="." instance=ExtResource("2_q0te6")]
-material = SubResource("ShaderMaterial_i80tj")
+material = SubResource("ShaderMaterial_un07t")
 
 [node name="PipePistol" parent="." instance=ExtResource("9_kj7hj")]
 position = Vector2(-6, 1)

--- a/project/src/guns/GunComponent.gd
+++ b/project/src/guns/GunComponent.gd
@@ -19,3 +19,16 @@ func attack():
 	bullet.update(projectile_speed, facing_angle)
 	bullet.global_position = projectile_start.global_position
 	Signals.emit_signal("projectile_shot")
+
+func _get_rotation_angle():
+	var direction_vector = Input.get_vector("aim_left", "aim_right", "aim_up", "aim_down")
+	var rotation_angle = direction_vector.angle()
+	return rotation_angle
+
+func rotate_gun_right():
+		self.rotation = _get_rotation_angle()
+		look_at(get_global_mouse_position())
+
+func rotate_gun_left():
+		self.rotation = -_get_rotation_angle() + PI
+		look_at(get_global_mouse_position())

--- a/project/src/guns/GunComponent.gd
+++ b/project/src/guns/GunComponent.gd
@@ -24,17 +24,26 @@ func attack():
 	Signals.emit_signal("projectile_shot")
 
 func rotate_gun(is_facing_left: bool):
-	var aim_direction_vector: Vector2 = _get_stick_direction_vector()
+	if _is_mouse():
+		_mouse_rotate_gun(is_facing_left)
 	
-	if aim_direction_vector != Vector2.ZERO:
-		var rotation_angle = aim_direction_vector.angle()
-		if is_facing_left:
-			_rotate_gun_left(rotation_angle)
-		else:
-			_rotate_gun_right(rotation_angle)
+	if _is_joypad():
+		_joypad_rotate_gun(is_facing_left)
 
 func _is_mouse() -> bool:
 	return controller == Controller.MOUSE
+
+func _mouse_rotate_gun_right():
+	look_at(get_global_mouse_position())
+
+func _mouse_rotate_gun_left():
+	look_at(get_global_mouse_position())
+
+func _mouse_rotate_gun(is_facing_left: bool):
+	if is_facing_left:
+		_mouse_rotate_gun_left()
+	else:
+		_mouse_rotate_gun_right()
 
 func _is_joypad() -> bool:
 	return controller == Controller.JOYPAD
@@ -42,23 +51,25 @@ func _is_joypad() -> bool:
 func _get_stick_direction_vector() -> Vector2:
 	return Vector2(Input.get_axis("aim_left", "aim_right"), Input.get_axis("aim_up", "aim_down"))
 
-func _rotate_gun_right(rotation_angle):
-		if _is_joypad():
-			self.rotation = lerp_angle(self.rotation, rotation_angle, 0.5)
-		if _is_mouse():
-			look_at(get_global_mouse_position())
-		return rotation
+func _joypad_rotate_gun_right(rotation_angle):
+	self.rotation = lerp_angle(self.rotation, rotation_angle, 0.5)
 
-func _rotate_gun_left(rotation_angle):
-		if _is_joypad():
-			self.rotation = lerp_angle(self.rotation, -(rotation_angle + PI), 0.5)
-		if _is_mouse():
-			look_at(get_global_mouse_position())
-		return rotation
+func _joypad_rotate_gun_left(rotation_angle):
+	self.rotation = lerp_angle(self.rotation, -(rotation_angle + PI), 0.5)
+
+func _joypad_rotate_gun(is_facing_left: bool):
+	var aim_direction_vector: Vector2 = _get_stick_direction_vector()
+	
+	if aim_direction_vector != Vector2.ZERO:
+		var rotation_angle = aim_direction_vector.angle()
+		if is_facing_left:
+			_joypad_rotate_gun_left(rotation_angle)
+		else:
+			_joypad_rotate_gun_right(rotation_angle)
 
 func _unhandled_input(event):
 	if event is InputEventJoypadMotion:
 		controller = Controller.JOYPAD
 
-	if event is InputEventMouse:
+	if event is InputEventKey:
 		controller = Controller.MOUSE


### PR DESCRIPTION
* player controler can rotate gun with controller and/or mouse:
	* gun_component.rotate_right()
	* gun_component.rotate_left()
* controller support depends on #163
* closes #164 

https://github.com/loteque/wasteland-warrior/assets/69282314/cc9aa7b0-f087-44b6-928e-858e0fe356e5


